### PR TITLE
Support Laravel 5.4

### DIFF
--- a/src/ConsoleServiceProvider.php
+++ b/src/ConsoleServiceProvider.php
@@ -20,7 +20,8 @@ class ConsoleServiceProvider extends ServiceProvider {
      */
     public function boot(Router $router)
     {
-        $router->middleware('console_protect', Http\Middlewares\Console::class);
+        $middlewareMethod = method_exists($router, 'aliasMiddleware') ? 'aliasMiddleware' : 'middleware';
+        $router->$middlewareMethod('console_protect', Http\Middlewares\Console::class);
 
         // Publish config.
         $this->publishes([


### PR DESCRIPTION
The `middleware` method of the `Illuminate\Routing\Router` class has been renamed to `aliasMiddleware()`.

For more information, see the "_Routing_" section of:  https://laravel.com/docs/5.4/upgrade